### PR TITLE
Fix active tab bottom border

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ exports.decorateConfig = (config) => {
       .tab_tab {
         border: 0;
       }
-      .tab_active::before {
+      .tab_textActive {
         border-bottom: 2px solid #009688;
       }
     `


### PR DESCRIPTION
Fixes https://github.com/dperrera/hyperterm-material/issues/6.

I'm not sure if the classes were updated when HyperTerm became Hyper, but this appears to fix the active tab bottom border issue.
