### PR TITLE
Change HyperTerm to Hyper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hyperterm Material
 
-A material design inspired theme plugin for [HyperTerm](https://hyperterm.org).
+A material design inspired theme plugin for [Hyper](https://hyper.is/).
 
 ![Screenshot](/images/hyperterm-material.png)
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "url" : "https://github.com/dperrera/hyperterm-material"
   },
   "version": "0.1.6",
-  "description": "A material inspired theme for hyperterm.",
+  "description": "A material inspired theme for Hyper.",
   "main": "index.js",
   "keywords": [
     "hyperterm",


### PR DESCRIPTION
The project was renamed recently. Maybe it would be better to rename npm module and main repo? What do you think?