### PR TITLE
Add split pane styles (new feature of Hyper)

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,9 @@ exports.decorateConfig = (config) => {
       .tab_textActive {
         border-bottom: 2px solid #009688;
       }
+      .splitpane_divider {
+        background-color: rgba(170, 187, 195, 0.16) !important;
+      }
     `
   })
 }


### PR DESCRIPTION
### Split pane before:
![split-pane-before](https://cloud.githubusercontent.com/assets/1968098/19945809/69f04ece-a14a-11e6-970a-a72f0377cda5.png)

---
### Split pane after:
![split-pane-after png](https://cloud.githubusercontent.com/assets/1968098/19945814/7388e220-a14a-11e6-8a56-2082db406749.png)

---

// *I pick a color from Atom Editor pane divider line (material theme).*