### PR TITLE
Dim inactive panes

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,6 +39,14 @@ exports.decorateConfig = (config) => {
       .splitpane_divider {
         background-color: rgba(170, 187, 195, 0.16) !important;
       }
+      .term_term {
+        opacity: 0.5;
+        transition: opacity 0.15s ease-in-out;
+        will-change: opacity;
+      }
+      .term_active .term_term {
+        opacity: 1;
+      }
     `
   })
 }


### PR DESCRIPTION
Because active and inactive panes are currently visually identical, I often accidentally type into the wrong pane. This makes that somewhat harder. A preview:

![preview](https://user-images.githubusercontent.com/6688324/31363162-6303330a-ad11-11e7-939e-955b9e8506ee.png)
